### PR TITLE
refactor: use promise in pick and add types

### DIFF
--- a/packages/framebuffer-picker/src/ColorMaterial.ts
+++ b/packages/framebuffer-picker/src/ColorMaterial.ts
@@ -9,7 +9,7 @@ Shader.create("framebuffer-picker-color", vs, fs);
  */
 export class ColorMaterial extends Material {
   private _currentId: number = 0;
-  private _primitivesMap = [];
+  private _primitivesMap: RenderElement[] = [];
 
   constructor(engine: Engine) {
     super(engine, Shader.find("framebuffer-picker-color"));
@@ -55,9 +55,8 @@ export class ColorMaterial extends Material {
    * @override
    */
   _preRender(renderElement: RenderElement) {
-    const { component, mesh } = renderElement;
     this._currentId += 1;
-    this._primitivesMap[this._currentId] = { component, mesh };
-    component.shaderData.setVector3("u_colorId", this.id2Color(this._currentId));
+    this._primitivesMap[this._currentId] = renderElement;
+    renderElement.component.shaderData.setVector3("u_colorId", this.id2Color(this._currentId));
   }
 }

--- a/packages/framebuffer-picker/src/ColorRenderPass.ts
+++ b/packages/framebuffer-picker/src/ColorRenderPass.ts
@@ -6,14 +6,14 @@ import { ColorMaterial } from "./ColorMaterial";
  */
 class ColorRenderPass extends RenderPass {
   private _needPick: boolean;
-  private onPick: Function;
-  private _pickPos;
+  private _pickPos: [number, number];
+  /** @internal */
+  _pickResolve: Function;
 
   constructor(name: string, priority: number, renderTarget: RenderTarget, mask: Layer, engine?: Engine) {
     super(name, priority, renderTarget, new ColorMaterial(engine), mask);
 
     this._needPick = false;
-    this.onPick = (o: any) => console.log(o);
   }
 
   /**
@@ -36,10 +36,10 @@ class ColorRenderPass extends RenderPass {
   postRender(camera: Camera) {
     if (this._needPick) {
       const color = this.readColorFromRenderTarget(camera);
-      const object = (this.replaceMaterial as ColorMaterial).getObjectByColor(color);
+      const renderElement = (this.replaceMaterial as ColorMaterial).getObjectByColor(color);
       this._needPick = false;
 
-      if (this.onPick) this.onPick(object);
+      if (this._pickResolve) this._pickResolve(renderElement);
     }
   }
 

--- a/packages/framebuffer-picker/src/FramebufferPicker.ts
+++ b/packages/framebuffer-picker/src/FramebufferPicker.ts
@@ -1,4 +1,4 @@
-import { Camera, Entity, RenderTarget, Script, Texture2D } from "oasis-engine";
+import { Camera, Entity, RenderElement, RenderTarget, Script, Texture2D } from "oasis-engine";
 import { ColorRenderPass } from "./ColorRenderPass";
 
 /**
@@ -37,24 +37,17 @@ export class FramebufferPicker extends Script {
   }
 
   /**
-   * Set the callback function after pick up.
-   * @param {Function} fun Callback function. if there is an renderer selected, the parameter 1 is {component, primitive }, otherwise it is undefined
-   */
-  set onPick(fun: Function) {
-    if (typeof fun === "function") {
-      (this.colorRenderPass as any).onPick = fun;
-    }
-  }
-
-  /**
    * Pick the object at the screen coordinate position.
    * @param offsetX Relative X coordinate of the canvas
    * @param offsetY Relative Y coordinate of the canvas
    */
-  pick(offsetX: number, offsetY: number) {
+  pick(offsetX: number, offsetY: number): Promise<RenderElement> {
     if (this.enabled) {
       this._needPick = true;
       this._pickPos = [offsetX, offsetY];
+      return new Promise((resolve) => {
+        this.colorRenderPass._pickResolve = resolve;
+      });
     }
   }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Refactor.
### What is the current behavior? (You can also link to an open issue here)
```
framebufferPicker.pick(e.offsetX, e.offsetY);
framebufferPicker.onPick = (obj)=>{
    const {component,mesh} = obj;
}
```
### What is the new behavior (if this is a feature change)?
```
framebufferPicker.pick(e.offsetX, e.offsetY).then((renderElemement)=>{
const {component,mesh,material,submesh} = renderElement
})

```
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Yes. `onPick` has delete.
### Other information: