### PR TITLE
Fix `Stats` automatic opening problem

### DIFF
--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -1,6 +1,1 @@
-import { Engine } from "oasis-engine";
-import { Stats } from "./Stats";
-
-Engine.registerFeature(Stats);
-
-export { Stats };
+export { Stats } from "./Stats";


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)