### PR TITLE
Feat: `OrbitControl` does not limit the vertical rotation angle

### DIFF
--- a/packages/controls/src/OrbitControl.ts
+++ b/packages/controls/src/OrbitControl.ts
@@ -150,10 +150,6 @@ export class OrbitControl extends Script {
       }
     }
     const { _sphericalDump, _sphericalDelta } = this;
-    if (this.autoRotate) {
-      const rotateAngle = (this.autoRotateSpeed / 1000) * deltaTime;
-      this._sphericalDelta.theta -= rotateAngle;
-    }
     if (this.enableDamping) {
       if (enableHandler & ControlHandlerType.ZOOM && curHandlerType ^ ControlHandlerType.ZOOM) {
         this._zoomFrag *= 1 - this.zoomFactor;
@@ -162,6 +158,10 @@ export class OrbitControl extends Script {
         _sphericalDelta.theta = _sphericalDump.theta *= 1 - this.dampingFactor;
         _sphericalDelta.phi = _sphericalDump.phi *= 1 - this.dampingFactor;
       }
+    }
+    if (this.autoRotate) {
+      const rotateAngle = (this.autoRotateSpeed / 1000) * deltaTime;
+      _sphericalDelta.theta -= rotateAngle;
     }
   }
 

--- a/packages/controls/src/OrbitControl.ts
+++ b/packages/controls/src/OrbitControl.ts
@@ -159,7 +159,7 @@ export class OrbitControl extends Script {
         _sphericalDelta.phi = _sphericalDump.phi *= 1 - this.dampingFactor;
       }
     }
-    if (this.autoRotate) {
+    if (curHandlerType === ControlHandlerType.None && this.autoRotate) {
       const rotateAngle = (this.autoRotateSpeed / 1000) * deltaTime;
       _sphericalDelta.theta -= rotateAngle;
     }

--- a/packages/controls/src/OrbitControl.ts
+++ b/packages/controls/src/OrbitControl.ts
@@ -16,10 +16,6 @@ export class OrbitControl extends Script {
   camera: Camera;
   cameraTransform: Transform;
 
-  /** Target position. */
-  target: Vector3 = new Vector3();
-  /** Up vector */
-  up: Vector3 = new Vector3(0, 1, 0);
   /** Whether to automatically rotate the camera, the default is false. */
   autoRotate: boolean = false;
   /** The radian of automatic rotation per second. */
@@ -46,15 +42,18 @@ export class OrbitControl extends Script {
   minZoom: number = 0.0;
   /** Maximum zoom speed, the default is positive infinity. */
   maxZoom: number = Infinity;
-  /** The minimum radian in the vertical direction, the default is 0 radian, the value range is 0 - Math.PI. */
-  minPolarAngle: number = 0.0;
-  /** The maximum radian in the vertical direction, the default is Math.PI, and the value range is 0 - Math.PI. */
-  maxPolarAngle: number = Math.PI;
+  /** The minimum radian in the vertical direction, the default is 0.1 degree. */
+  minPolarAngle: number = 0.1;
+  /** The maximum radian in the vertical direction,  the default is 179.9 degree.  */
+  maxPolarAngle: number = (179.9 / 180) * Math.PI;
   /** The minimum radian in the horizontal direction, the default is negative infinity. */
   minAzimuthAngle: number = -Infinity;
   /** The maximum radian in the horizontal direction, the default is positive infinity.  */
   maxAzimuthAngle: number = Infinity;
 
+  private _up: Vector3 = new Vector3(0, 1, 0);
+  private _target: Vector3 = new Vector3();
+  private _atTheBack: boolean = false;
   private _spherical: Spherical = new Spherical();
   private _sphericalDelta: Spherical = new Spherical();
   private _sphericalDump: Spherical = new Spherical();
@@ -63,6 +62,32 @@ export class OrbitControl extends Script {
   private _panOffset: Vector3 = new Vector3();
   private _tempVec3: Vector3 = new Vector3();
   private _enableHandler: number = ControlHandlerType.All;
+
+  /**
+   * Return up vector.
+   */
+  get up(): Vector3 {
+    return this._up;
+  }
+
+  set up(value: Vector3) {
+    this._up.copyFrom(value);
+    this._spherical.setUp(value);
+    this._atTheBack = false;
+  }
+
+  /**
+   * Return target position.
+   * */
+  get target(): Vector3 {
+    return this._target;
+  }
+
+  set target(value: Vector3) {
+    this._target.copyFrom(value);
+    this._spherical.setUp(value);
+    this._atTheBack = false;
+  }
 
   /**
    *  Return Whether to enable rotation, the default is true.
@@ -115,6 +140,8 @@ export class OrbitControl extends Script {
     this.input = engine.inputManager;
     this.camera = entity.getComponent(Camera);
     this.cameraTransform = entity.transform;
+    this._spherical.setUp(this._up);
+    this._atTheBack = false;
   }
 
   onUpdate(deltaTime: number): void {
@@ -200,21 +227,20 @@ export class OrbitControl extends Script {
   private _updateTransform(): void {
     const { cameraTransform, target, _tempVec3, _spherical, _sphericalDelta, _panOffset } = this;
     Vector3.subtract(cameraTransform.position, target, _tempVec3);
-    _spherical.setFromVec3(_tempVec3);
+    _spherical.setFromVec3(_tempVec3, this._atTheBack);
     _spherical.theta += _sphericalDelta.theta;
     _spherical.phi += _sphericalDelta.phi;
     _spherical.theta = Math.max(this.minAzimuthAngle, Math.min(this.maxAzimuthAngle, _spherical.theta));
     _spherical.phi = Math.max(this.minPolarAngle, Math.min(this.maxPolarAngle, _spherical.phi));
     _spherical.makeSafe();
-
     if (this._scale !== 1) {
       this._zoomFrag = _spherical.radius * (this._scale - 1);
     }
     _spherical.radius += this._zoomFrag;
     _spherical.radius = Math.max(this.minDistance, Math.min(this.maxDistance, _spherical.radius));
-    _spherical.setToVec3(_tempVec3);
-    Vector3.add(target.add(_panOffset), _tempVec3, cameraTransform.position);
-    cameraTransform.lookAt(target, this.up);
+    this._atTheBack = _spherical.setToVec3(_tempVec3);
+    Vector3.add(target.add(_panOffset), _tempVec3, cameraTransform.worldPosition);
+    cameraTransform.lookAt(target, _tempVec3.copyFrom(this.up).scale(this._atTheBack ? -1 : 1));
     /** Reset cache value. */
     this._zoomFrag = 0;
     this._scale = 1;

--- a/packages/controls/src/Spherical.ts
+++ b/packages/controls/src/Spherical.ts
@@ -1,14 +1,22 @@
-import { MathUtil, Vector3 } from "oasis-engine";
-
+import { MathUtil, Matrix, Vector3 } from "oasis-engine";
 // Prevent gimbal lock.
 const ESP = MathUtil.zeroTolerance;
-
 // Spherical.
 export class Spherical {
+  private static xAxis: Vector3 = new Vector3();
+  private static yAxis: Vector3 = new Vector3();
+  private static zAxis: Vector3 = new Vector3();
+  private matrixInv: Matrix = new Matrix();
   constructor(public radius?: number, public phi?: number, public theta?: number) {
     this.radius = radius !== undefined ? radius : 1.0;
     this.phi = phi !== undefined ? phi : 0;
     this.theta = theta !== undefined ? theta : 0;
+  }
+
+  makeSafe() {
+    const count = Math.floor(this.phi / Math.PI);
+    this.phi = MathUtil.clamp(this.phi, count * Math.PI + ESP, (count + 1) * Math.PI - ESP);
+    return this;
   }
 
   set(radius: number, phi: number, theta: number) {
@@ -18,19 +26,34 @@ export class Spherical {
     return this;
   }
 
-  makeSafe() {
-    this.phi = MathUtil.clamp(this.phi, ESP, Math.PI - ESP);
-    return this;
+  setUp(up: Vector3) {
+    const { xAxis, yAxis, zAxis } = Spherical;
+    if (Vector3.equals(xAxis.set(1, 0, 0), yAxis.copyFrom(up).normalize())) {
+      xAxis.set(0, 1, 0);
+    }
+    Vector3.cross(xAxis, yAxis, zAxis);
+    zAxis.normalize();
+    Vector3.cross(yAxis, zAxis, xAxis);
+    const { elements: eInv } = this.matrixInv;
+    (eInv[0] = xAxis.x), (eInv[4] = xAxis.y), (eInv[8] = xAxis.z);
+    (eInv[1] = yAxis.x), (eInv[5] = yAxis.y), (eInv[9] = yAxis.z);
+    (eInv[2] = zAxis.x), (eInv[6] = zAxis.y), (eInv[10] = zAxis.z);
   }
 
-  setFromVec3(value: Vector3) {
+  setFromVec3(value: Vector3, atTheBack: boolean = false) {
+    value.transformNormal(this.matrixInv);
     this.radius = value.length();
     if (this.radius === 0) {
       this.theta = 0;
       this.phi = 0;
     } else {
-      this.theta = Math.atan2(value.x, value.z);
-      this.phi = Math.acos(MathUtil.clamp(value.y / this.radius, -1, 1));
+      if (atTheBack) {
+        this.phi = 2 * Math.PI - Math.acos(MathUtil.clamp(value.y / this.radius, -1, 1));
+        this.theta = Math.atan2(-value.x, -value.z);
+      } else {
+        this.phi = Math.acos(MathUtil.clamp(value.y / this.radius, -1, 1));
+        this.theta = Math.atan2(value.x, value.z);
+      }
     }
     return this;
   }
@@ -38,7 +61,8 @@ export class Spherical {
   setToVec3(value: Vector3) {
     const { radius, phi, theta } = this;
     const sinPhiRadius = Math.sin(phi) * radius;
+    this.phi -= Math.floor(this.phi / Math.PI / 2) * Math.PI * 2;
     value.set(sinPhiRadius * Math.sin(theta), radius * Math.cos(phi), sinPhiRadius * Math.cos(theta));
-    return this;
+    return this.phi > Math.PI;
   }
 }


### PR DESCRIPTION
Previously, `OrbitControl` would limit the rotation in vertical space between 0 and 180 degrees, but now this limit is removed.
```
  const control = cameraEntity.addComponent(OrbitControl);
  control.minPolarAngle = -Infinity;
  control.maxPolarAngle = Infinity;
```